### PR TITLE
Update gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,6 @@ function views() {
         pretty: true
     }))
     .pipe(gulp.dest('./'))
-    .pipe(connect.reload())
   )
 }
 


### PR DESCRIPTION
prevent double page refresh by not reloading inside `views` – it will reload in `html` anyway, which significantly improves performance